### PR TITLE
Fix missing dj_database_url import in settings.py

### DIFF
--- a/causehive_monolith/settings.py
+++ b/causehive_monolith/settings.py
@@ -14,6 +14,7 @@ import os
 from pathlib import Path
 from datetime import timedelta
 import environ
+import dj_database_url
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
- Added missing import dj_database_url to fix NameError during deployment
- This should resolve the crash during database migration