### PR TITLE
Add missing django-extensions to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ requests==2.32.3
 paystack==1.5.0
 gunicorn==22.0.0
 dj-database-url==2.1.0
+django-extensions==3.2.3
 
 # Development dependencies (optional)
 django-debug-toolbar>=4.0.0


### PR DESCRIPTION
- Fixed ModuleNotFoundError: No module named 'django_extensions'
- Added django-extensions==3.2.3 to requirements.txt
- This should resolve the deployment crash during Django setup